### PR TITLE
Allow for setting individual audience segmentation attributes

### DIFF
--- a/docs/dead-code-removal.md
+++ b/docs/dead-code-removal.md
@@ -266,10 +266,17 @@ base relatively clean while running multiple experiments.
 
 ## Improvement points
 
-All functions in the toggles should be double arrow functions, to preserve the
-scope while executing winning toggles.
+### When using functions for variations
 
-## Coding Conventions
+All functions in the toggles should be double arrow or bound functions, to
+preserve the scope while executing winning toggles.
+
+Since the winner implementation only and fully preserves the _body_ of the
+winning function (it is statically analyzed, not executed), it's not advised to
+return a value when using a function, as it can result in unexpected behavior
+returning early.
+
+## Coding Style Conventions
 
 When the codemods rewrite your code, the resulting output might not match your
 coding conventions such as the use of semicolons. This project doesn't attempt

--- a/src/integrations/__fixtures__/dataFile.js
+++ b/src/integrations/__fixtures__/dataFile.js
@@ -77,7 +77,11 @@ export default {
         '[ "and", { "name": "trafficSource", "value": "foo", "type": "custom_attribute" }, { "name": "hasDefaultDates", "value": true, "type": "custom_attribute" }, ["not", { "name": "deviceType", "value": "mobile", "type": "custom_attribute" } ] ]'
     }
   ],
-  attributes: [{ id: 'trafficSource', key: 'trafficSource' }],
+  attributes: [
+    { id: 'trafficSource', key: 'trafficSource' },
+    { id: 'hasDefaultDates', key: 'hasDefaultDates' },
+    { id: 'deviceType', key: 'deviceType' }
+  ],
   groups: [],
   rollouts: [],
   variables: []

--- a/src/integrations/optimizely.js
+++ b/src/integrations/optimizely.js
@@ -8,8 +8,11 @@ import { NOTIFICATION_TYPES } from '@optimizely/optimizely-sdk/lib/utils/enums'
 import type OptimizelyLibType from '@optimizely/optimizely-sdk'
 
 type UserIdType = string
+type AudienceSegmentationAttributeKeyType = string
+type AudienceSegmentationAttributeValueType = string | boolean
+
 type AudienceSegmentationAttributesType = {
-  [string]: string | boolean
+  [AudienceSegmentationAttributeKeyType]: AudienceSegmentationAttributeValueType
 }
 
 type ToggleValueType = string | boolean
@@ -43,6 +46,15 @@ export const setAudienceSegmentationAttributes = (
   clearExperimentCache()
   userId = id
   audienceSegmentationAttributes = attributes
+}
+
+export const setAudienceSegmentationAttribute = (
+  key: AudienceSegmentationAttributeKeyType,
+  value: AudienceSegmentationAttributeValueType
+) => {
+  clearFeatureEnabledCache()
+  clearExperimentCache()
+  audienceSegmentationAttributes[key] = value
 }
 
 type ActivateEventHandlerType = Function


### PR DESCRIPTION
Adds ability to set / override an individual audience segmentation attribute, as `setAudienceSegmentationAttributes` would override all previously set attributes.

Fix #11.