### PR TITLE
Expose jscodeshift for consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "flow-copy-source": "^2.0.2",
     "flow-typed": "^2.5.1",
     "jest": "^23.6.0",
-    "jscodeshift": "^0.5.1",
     "prettier-eslint-cli": "^4.7.1",
     "regenerator-runtime": "^0.12.1",
     "rollup": "^0.68.2",
@@ -71,5 +70,8 @@
     "rollup-plugin-flow": "^1.1.1",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-terser": "^3.0.0"
+  },
+  "dependencies": {
+    "jscodeshift": "^0.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "author": "Jop de Klein",
   "license": "ISC",
   "peerDependencies": {
-    "@optimizely/optimizely-sdk": "^3.0.1"
+    "@optimizely/optimizely-sdk": "^3.0.1",
+    "jscodeshift": "^0.5.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -61,6 +62,7 @@
     "flow-copy-source": "^2.0.2",
     "flow-typed": "^2.5.1",
     "jest": "^23.6.0",
+    "jscodeshift": "^0.5.1",
     "prettier-eslint-cli": "^4.7.1",
     "regenerator-runtime": "^0.12.1",
     "rollup": "^0.68.2",
@@ -70,8 +72,5 @@
     "rollup-plugin-flow": "^1.1.1",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-terser": "^3.0.0"
-  },
-  "dependencies": {
-    "jscodeshift": "^0.5.1"
   }
 }

--- a/src/transform/__tests__/toggle.test.js
+++ b/src/transform/__tests__/toggle.test.js
@@ -44,6 +44,23 @@ const result = 'b'
     )
   })
 
+  describe('Test Name with dashes', () => {
+    defineInlineTest(
+      transform,
+      {
+        toggle: 'foo-bar-baz-dash-boom',
+        winner: 'a'
+      },
+      `
+import { toggle } from '${packageName}'
+const result = toggle('foo-bar-baz-dash-boom', 'a', 'b', 'c')
+`,
+      `
+const result = 'a'
+  `
+    )
+  })
+
   describe('Keeps the import for non-relevant toggle calls', () => {
     defineInlineTest(
       transform,


### PR DESCRIPTION
This way the consumers of Opticks don't need to install jscodeshift themselves, and we tie our expectations of the version of JSCodeshift to Opticks.

Fixes #21.