### PR TITLE
CodeMods: Unused variable cleanup

### DIFF
--- a/src/transform/__tests__/toggle.test.js
+++ b/src/transform/__tests__/toggle.test.js
@@ -136,6 +136,24 @@ const foo = 'bar'
     )
   })
 
+  describe('Removing unused variables in losing variations', () => {
+    defineInlineTest(
+      transform,
+      fooWinnerBConfig,
+      `
+import { toggle } from '${packageName}'
+const A = 'A'
+const B = 'B'
+const C = 'C'
+const result = toggle('foo', () => A(), () => B(), () => C())
+`,
+      `
+const B = 'B'
+const result = B()
+  `
+    )
+  })
+
   describe('Deals with missing options', () => {
     const code = `
 import { toggle } from '${packageName}'

--- a/src/transform/__tests__/toggle.test.js
+++ b/src/transform/__tests__/toggle.test.js
@@ -44,6 +44,23 @@ const result = 'b'
     )
   })
 
+  describe('Test Name with dashes', () => {
+    defineInlineTest(
+      transform,
+      {
+        toggle: 'foo-bar-baz-dash-boom',
+        winner: 'a'
+      },
+      `
+import { toggle } from '${packageName}'
+const result = toggle('foo-bar-baz-dash-boom', 'a', 'b', 'c')
+`,
+      `
+const result = 'a'
+  `
+    )
+  })
+
   describe('Keeps the import for non-relevant toggle calls', () => {
     defineInlineTest(
       transform,


### PR DESCRIPTION
Cleans up variables in losing toggle variations if they are not used anywhere else.