### PR TITLE
Stop hardcoding flow parser for JSCodeShift codemods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 > - :house: [Internal]
 > - :nail_care: [Polish]
 
+# v3.3.1
+- :house: Make JSCodeShift parser configurable
+
 # v3.3.0
 - :rocket: Add getEnabledFeatures method.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opticks",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "FindHotel Toggle Flag JavaScript SDK",
   "main": "lib/simple.js",
   "files": [

--- a/src/transform/__tests__/booleanToggle.test.js
+++ b/src/transform/__tests__/booleanToggle.test.js
@@ -223,7 +223,7 @@ const result = <div>Foo</div>
       fooLoserOptions,
       `
 import { booleanToggle } from '${packageName}'
-const Foo = () => void
+const Foo = () => null
 const result = <div>Foo{booleanToggle('foo', () => Foo())}</div>
 `,
       `

--- a/src/transform/booleanToggle.js
+++ b/src/transform/booleanToggle.js
@@ -1,7 +1,5 @@
 // @flow
 
-module.exports.parser = 'flow'
-
 const PACKAGE_NAME = 'opticks'
 const BOOLEAN_TOGGLE_FUNCTION_NAME = 'booleanToggle'
 

--- a/src/transform/toggle.js
+++ b/src/transform/toggle.js
@@ -1,7 +1,5 @@
 // @flow
 
-module.exports.parser = 'flow'
-
 const PACKAGE_NAME = 'opticks'
 const FUNCTION_NAME = 'toggle'
 


### PR DESCRIPTION
Previously we hardcoded the Flow parser for the  JSCodeShift codemods, now we leave it up to the consumer to specify the parser and extensions to be transformed.