### PR TITLE
Fix variable cleanup that was too aggressive and cleaned optimistically

### DIFF
--- a/.changeset/smart-drinks-fold.md
+++ b/.changeset/smart-drinks-fold.md
@@ -2,4 +2,6 @@
 'opticks': minor
 ---
 
+:rocket: Codemods: Hardcode the TSX parser
+:bug: Codemods: Fix null removal for the TSX parser
 :bug: Codemods: Fix variable cleanup that was too aggressive and cleaned optimistically

--- a/.changeset/smart-drinks-fold.md
+++ b/.changeset/smart-drinks-fold.md
@@ -5,3 +5,4 @@
 :rocket: Codemods: Hardcode the TSX parser
 :bug: Codemods: Fix null removal for the TSX parser
 :bug: Codemods: Fix variable cleanup that was too aggressive and cleaned optimistically
+:chore: Codemods: Clean up dangling JSX expressions such as {<B/>} -> <B/>

--- a/.changeset/smart-drinks-fold.md
+++ b/.changeset/smart-drinks-fold.md
@@ -2,4 +2,4 @@
 'opticks': minor
 ---
 
-Codemods: Fix variable cleanup that was too aggressive and cleaned optimistically
+:bug: Codemods: Fix variable cleanup that was too aggressive and cleaned optimistically

--- a/.changeset/smart-drinks-fold.md
+++ b/.changeset/smart-drinks-fold.md
@@ -1,0 +1,5 @@
+---
+'opticks': minor
+---
+
+Codemods: Fix variable cleanup that was too aggressive and cleaned optimistically

--- a/docs/dead-code-removal.md
+++ b/docs/dead-code-removal.md
@@ -70,6 +70,10 @@ Then you can run it right from your project:
 npm run clean:toggle -- --toggle=foo --winner=b
 ```
 
+### Supported languages
+
+The codemods are designed to work with TypeScript and they expect the `tsx` parser to be used. You can override the parser option from the consuming project to parse code other than TypeScript, but not all patterns might be cleaned up as intended.
+
 ### Boolean Toggles
 
 Boolean Toggle clean up works in a similar way, noting the winner accepts a

--- a/docs/dead-code-removal.md
+++ b/docs/dead-code-removal.md
@@ -288,13 +288,18 @@ returning early.
 ## Coding Style Conventions
 
 When the codemods rewrite your code, the resulting output might not match your
-coding conventions such as the use of semicolons. This project doesn't attempt
-to apply any pretty printing itself as your needs might vary from others. It is
-recommended to run ESLint with the `--fix` option, Prettier, or another pretty
-print tool after running the codemods to ensure uniformity in your codebase.
+coding conventions, such as the use of semicolons. This project doesn't attempt
+to apply any pretty printing itself, as your needs will vary from other's.
 
 See https://github.com/benjamn/recast/issues/140#issuecomment-69794531 for more
 details.
+
+The strategy is to offload as much as possible to existing tools, and we
+recommended running ESLint with the `--fix` option, Prettier, or another
+pretty print tool after running the codemods to ensure uniformity in your codebase.
+
+The [eslint-plugin-unused-imports](https://github.com/sweepline/eslint-plugin-unused-imports)
+plugin can be used to remove lingering import statements after cleanup.
 
 ## Request For Comments
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "build": "tsup",
     "lint": "eslint --ignore-path .eslintignore --ext .js,.ts .",
-    "clean:booleanToggle": "jscodeshift --transform lib/transform/booleanToggle.js",
-    "clean:toggle": "jscodeshift --transform lib/transform/toggle.js",
+    "clean:booleanToggle": "jscodeshift --transform lib/transform/booleanToggle.js  --parser=tsx --extensions=ts,tsx",
+    "clean:toggle": "jscodeshift --transform lib/transform/toggle.js --parser=tsx --extensions=ts,tsx",
     "jscodeshift": "jscodeshift",
     "prepare": "npm run build",
     "release": "npm run prepare && npx changeset publish",

--- a/src/transform/__tests__/booleanToggle.test.ts
+++ b/src/transform/__tests__/booleanToggle.test.ts
@@ -2,6 +2,8 @@ jest.autoMockOff()
 
 import {defineInlineTest} from 'jscodeshift/dist/testUtils'
 import transform from '../booleanToggle'
+// @ts-expect-error: default to TSX parser
+transform.parser = 'tsx'
 
 const packageName = 'opticks'
 const fooWinnerOptions = {

--- a/src/transform/__tests__/toggle.test.ts
+++ b/src/transform/__tests__/toggle.test.ts
@@ -2,6 +2,8 @@ jest.autoMockOff()
 
 import {defineInlineTest} from 'jscodeshift/dist/testUtils'
 import transform from '../toggle'
+// @ts-expect-error: default to TSX parser
+transform.parser = 'tsx'
 
 const packageName = 'opticks'
 const fooWinnerAConfig = {
@@ -127,9 +129,13 @@ const result = {foo(); bar()}
 import { toggle } from '${packageName}'
 const foo = 'bar'
 toggle('foo', 'a', null, 'c')
+
+const X = () => <div>{toggle('foo', 'a', null)}</div>
 `,
       `
 const foo = 'bar'
+
+const X = () => <div>{}</div>
   `
     )
   })

--- a/src/transform/__tests__/toggle.test.ts
+++ b/src/transform/__tests__/toggle.test.ts
@@ -219,6 +219,22 @@ C()
     )
   })
 
+  describe('Removing unused variables if defined in a template literal', () => {
+    defineInlineTest(
+      transform,
+      fooWinnerBConfig,
+      `
+import { toggle } from '${packageName}'
+const removeMe = 'a'
+
+const Foo = toggle('foo', () => \`\${removeMe}\`, 'keepme')
+`,
+      `
+const Foo = 'keepme'
+  `
+    )
+  })
+
   describe('Deals with missing options', () => {
     const code = `
 import { toggle } from '${packageName}'

--- a/src/transform/__tests__/toggle.test.ts
+++ b/src/transform/__tests__/toggle.test.ts
@@ -140,13 +140,13 @@ const foo = 'bar'
       fooWinnerBConfig,
       `
 import { toggle } from '${packageName}'
-const A = 'A'
-const B = 'B'
-const C = 'C'
+const A = 'removeme'
+const B = 'keepme'
+const C = 'removeme'
 const result = toggle('foo', () => A(), () => B(), () => C())
 `,
       `
-const B = 'B'
+const B = 'keepme'
 const result = B()
   `
     )
@@ -158,18 +158,18 @@ const result = B()
       fooWinnerBConfig,
       `
 import { toggle } from '${packageName}'
-const B = 'foo'
-const C = 'bar'
+const B = 'keepme'
+const C = 'removeme'
 const result = toggle('foo', () => B(), () => B(), () => C())
 `,
       `
-const B = 'foo'
+const B = 'keepme'
 const result = B()
   `
     )
   })
   
-  describe('Removing unused variables in losing variations, only if not used in imports', () => {
+  describe('Removing unused variables in losing variations, only if not used elsewhere', () => {
     defineInlineTest(
       transform,
       fooWinnerBConfig,
@@ -178,6 +178,35 @@ import { toggle } from '${packageName}'
 import {B} from 'somewhere'
 
 const A = 'removeme'
+const C = 'keepme'
+
+const result = toggle('foo', () => B(), () => B(), () => C())
+const result2 = toggle('foo', () => A(), () => B(), () => C())
+
+C()
+`,
+      `
+import {B} from 'somewhere'
+
+const C = 'keepme'
+
+const result = B()
+const result2 = B()
+
+C()
+  `
+    )
+  })
+
+  xdescribe('Removing unused imports in losing variations', () => {
+    defineInlineTest(
+      transform,
+      fooWinnerBConfig,
+      `
+import { toggle } from '${packageName}'
+import {A} from 'somewhere'
+import {B} from 'somewhere'
+
 const C = 'keepme'
 
 const result = toggle('foo', () => B(), () => B(), () => C())

--- a/src/transform/__tests__/toggle.test.ts
+++ b/src/transform/__tests__/toggle.test.ts
@@ -147,10 +147,24 @@ const Component = () => <div></div>
       `
 import { toggle } from '${packageName}'
 
-const Component = () => <div>{true ? 'yes' : 'no'}{toggle('foo', 'a', null)}{toggle('foo', 'a', <B/>)}</div>
+const Component = () => <div>
+  {true ? 'yes' : 'no'}
+  {toggle('foo', 'a', null)}
+  {toggle('foo', 'a', <B/>)}
+</div>
+const ShouldKeepExpression = () => <div>{
+  true ? toggle('foo', 'a', 'b') : null
+}</div>
 `,
       `
-const Component = () => <div>{true ? 'yes' : 'no'}<B/></div>
+const Component = () => <div>
+  {true ? 'yes' : 'no'}
+
+  <B/>
+</div>
+const ShouldKeepExpression = () => <div>{
+  true ? 'b' : null
+}</div>
   `
     )
   })

--- a/src/transform/__tests__/toggle.test.ts
+++ b/src/transform/__tests__/toggle.test.ts
@@ -130,12 +130,27 @@ import { toggle } from '${packageName}'
 const foo = 'bar'
 toggle('foo', 'a', null, 'c')
 
-const X = () => <div>{toggle('foo', 'a', null)}</div>
+const Component = () => <div>{toggle('foo', 'a', null)}</div>
 `,
       `
 const foo = 'bar'
 
-const X = () => <div>{}</div>
+const Component = () => <div></div>
+  `
+    )
+  })
+
+  describe('Removing unecessary expressions in JSX after toggle removal', () => {
+    defineInlineTest(
+      transform,
+      fooWinnerBConfig,
+      `
+import { toggle } from '${packageName}'
+
+const Component = () => <div>{true ? 'yes' : 'no'}{toggle('foo', 'a', null)}{toggle('foo', 'a', <B/>)}</div>
+`,
+      `
+const Component = () => <div>{true ? 'yes' : 'no'}<B/></div>
   `
     )
   })
@@ -174,7 +189,7 @@ const result = B()
   `
     )
   })
-  
+
   describe('Removing unused variables in losing variations, only if not used elsewhere', () => {
     defineInlineTest(
       transform,

--- a/src/transform/__tests__/toggle.test.ts
+++ b/src/transform/__tests__/toggle.test.ts
@@ -152,6 +152,52 @@ const result = B()
     )
   })
 
+  describe('Removing unused variables in losing variations, only if not used in other variations', () => {
+    defineInlineTest(
+      transform,
+      fooWinnerBConfig,
+      `
+import { toggle } from '${packageName}'
+const B = 'foo'
+const C = 'bar'
+const result = toggle('foo', () => B(), () => B(), () => C())
+`,
+      `
+const B = 'foo'
+const result = B()
+  `
+    )
+  })
+  
+  describe('Removing unused variables in losing variations, only if not used in imports', () => {
+    defineInlineTest(
+      transform,
+      fooWinnerBConfig,
+      `
+import { toggle } from '${packageName}'
+import {B} from 'somewhere'
+
+const A = 'removeme'
+const C = 'keepme'
+
+const result = toggle('foo', () => B(), () => B(), () => C())
+const result2 = toggle('foo', () => A(), () => B(), () => C())
+
+C()
+`,
+      `
+import {B} from 'somewhere'
+
+const C = 'keepme'
+
+const result = B()
+const result2 = B()
+
+C()
+  `
+    )
+  })
+
   describe('Deals with missing options', () => {
     const code = `
 import { toggle } from '${packageName}'
@@ -159,9 +205,5 @@ const result = toggle('foo', 'a', () => {foo(); bar()}, 'c')
 `
 
     defineInlineTest(transform, {}, code, code)
-  })
-
-  xdescribe('Removes references to unused variables in call expressions upon removal', () => {
-    // ... TODO
   })
 })

--- a/src/transform/__tests__/toggle.test.ts
+++ b/src/transform/__tests__/toggle.test.ts
@@ -198,35 +198,6 @@ C()
     )
   })
 
-  xdescribe('Removing unused imports in losing variations', () => {
-    defineInlineTest(
-      transform,
-      fooWinnerBConfig,
-      `
-import { toggle } from '${packageName}'
-import {A} from 'somewhere'
-import {B} from 'somewhere'
-
-const C = 'keepme'
-
-const result = toggle('foo', () => B(), () => B(), () => C())
-const result2 = toggle('foo', () => A(), () => B(), () => C())
-
-C()
-`,
-      `
-import {B} from 'somewhere'
-
-const C = 'keepme'
-
-const result = B()
-const result2 = B()
-
-C()
-  `
-    )
-  })
-
   describe('Deals with missing options', () => {
     const code = `
 import { toggle } from '${packageName}'

--- a/src/transform/booleanToggle.ts
+++ b/src/transform/booleanToggle.ts
@@ -43,7 +43,7 @@ const implementBooleanToggle = (j, isWinner: boolean, root, callExpression) => {
     if (winningArgument.type === 'ArrowFunctionExpression') {
       callPath.replaceWith(winningArgument.body)
     } else if (
-      winningArgument.type === 'Literal' &&
+      winningArgument.type === 'NullLiteral' &&
       winningArgument.value === null
     ) {
       removeCall(callExpression)

--- a/src/transform/toggle.ts
+++ b/src/transform/toggle.ts
@@ -62,11 +62,23 @@ const implementWinningToggle = (
     winningArgument.type === 'NullLiteral' &&
     winningArgument.value === null
   ) {
-    callPath.remove()
+    const closestJsxExpressions = callPath.closest(j.JSXExpressionContainer)
+
+    // if the parent is an JSX expression, remove it altogether
+    // <>{toggle('foo', <A/>, <B/>)}</> becomes <></B></>
+    closestJsxExpressions.length
+      ? closestJsxExpressions.remove()
+      : callPath.remove()
   } else {
     // use raw value
     callPath.replaceWith(node.arguments[winnerArgumentIndex])
   }
+
+  // clean up lingering JSX expessions with one JSXElement
+  callPath.closest(j.JSXExpressionContainer).forEach((node) => {
+    const expression = node.value.expression
+    if (expression.type === 'JSXElement') node.replace(node.value.expression)
+  })
 }
 
 const findToggleCalls = (j, context, localName) =>

--- a/src/transform/toggle.ts
+++ b/src/transform/toggle.ts
@@ -55,10 +55,9 @@ const implementWinningToggle = (
 
   // if a parent is an JSX expression, remove it altogether
   // <>{toggle('foo', <A/>, <B/>)}</> becomes <><B/></> and not <>{<B/>}<>
-  const closestJsxExpressions = callPath.closest(j.JSXExpressionContainer)
-  const nodeToClean = closestJsxExpressions.length
-    ? closestJsxExpressions
-    : callPath
+  const parent = callExpression.parentPath
+  const parentIsJSXExpression = parent.value.type === 'JSXExpressionContainer'
+  const nodeToClean = parentIsJSXExpression ? j(parent) : callPath
 
   // Winner implementation
   // function, use body

--- a/src/transform/toggle.ts
+++ b/src/transform/toggle.ts
@@ -54,7 +54,7 @@ const implementWinningToggle = (
   })
 
   // if a parent is an JSX expression, remove it altogether
-  // <>{toggle('foo', <A/>, <B/>)}</> becomes <></B></>
+  // <>{toggle('foo', <A/>, <B/>)}</> becomes <><B/></> and not <>{<B/>}<>
   const closestJsxExpressions = callPath.closest(j.JSXExpressionContainer)
   const nodeToClean = closestJsxExpressions.length
     ? closestJsxExpressions

--- a/src/transform/toggle.ts
+++ b/src/transform/toggle.ts
@@ -20,13 +20,12 @@ const implementWinningToggle = (
   const callPath = j(callExpression)
   const winningArgument = node.arguments[winnerArgumentIndex]
 
-  const notOfType = (type, node) => j(node).closest(type).size() === 0
-
+  // Looks for references only referred in the losing arrow function usage, 
+  // and one declaration - hence 2 in total
   const findUnusedReferencesOfType = (type, name) =>
     root
-      .find(j.Identifier, {name})
-      .filter(notOfType.bind(null, type))
-      .size() === 0
+      .find(j.Identifier, { name })
+      .size() === 2
 
   const removeUnusedReferences = (type, name, identifiers) =>
     root
@@ -34,13 +33,13 @@ const implementWinningToggle = (
       .filter(findUnusedReferencesOfType.bind(null, type, name))
       .remove()
 
-  // Clean up dangling losing variable references
   const losingArgumentFunctions = node.arguments.filter(
     (arg, index) =>
       arg.type === 'ArrowFunctionExpression' && index !== winnerArgumentIndex
   )
 
-  losingArgumentFunctions.forEach((losingFunction) => {
+  // Clean up dangling losing variable references
+  losingArgumentFunctions.forEach(losingFunction => {
     j(losingFunction.body)
       .find(j.Identifier)
       .forEach((x) => {
@@ -53,6 +52,8 @@ const implementWinningToggle = (
             name: name
           }
         })
+
+        // TODO: Remove imports too
       })
   })
 

--- a/src/transform/toggle.ts
+++ b/src/transform/toggle.ts
@@ -20,12 +20,10 @@ const implementWinningToggle = (
   const callPath = j(callExpression)
   const winningArgument = node.arguments[winnerArgumentIndex]
 
-  // Looks for references only referred in the losing arrow function usage, 
+  // Looks for references only referred in the losing arrow function usage,
   // and one declaration - hence 2 in total
   const findUnusedReferencesOfType = (name) =>
-    root
-      .find(j.Identifier, { name })
-      .size() === 2
+    root.find(j.Identifier, {name}).size() === 2
 
   const removeUnusedReferences = (type, name, identifiers) =>
     root
@@ -39,7 +37,7 @@ const implementWinningToggle = (
   )
 
   // Clean up dangling losing variable references
-  losingArgumentFunctions.forEach(losingFunction => {
+  losingArgumentFunctions.forEach((losingFunction) => {
     j(losingFunction.body)
       .find(j.Identifier)
       .forEach((x) => {

--- a/src/transform/toggle.ts
+++ b/src/transform/toggle.ts
@@ -61,7 +61,7 @@ const implementWinningToggle = (
     callPath.replaceWith(winningArgument.body)
   } else if (
     // null value, remove
-    winningArgument.type === 'Literal' &&
+    winningArgument.type === 'NullLiteral' &&
     winningArgument.value === null
   ) {
     callPath.remove()

--- a/src/transform/toggle.ts
+++ b/src/transform/toggle.ts
@@ -53,32 +53,27 @@ const implementWinningToggle = (
       })
   })
 
+  // if a parent is an JSX expression, remove it altogether
+  // <>{toggle('foo', <A/>, <B/>)}</> becomes <></B></>
+  const closestJsxExpressions = callPath.closest(j.JSXExpressionContainer)
+  const nodeToClean = closestJsxExpressions.length
+    ? closestJsxExpressions
+    : callPath
+
   // Winner implementation
   // function, use body
   if (winningArgument.type === 'ArrowFunctionExpression') {
-    callPath.replaceWith(winningArgument.body)
+    nodeToClean.replaceWith(winningArgument.body)
   } else if (
     // null value, remove
     winningArgument.type === 'NullLiteral' &&
     winningArgument.value === null
   ) {
-    const closestJsxExpressions = callPath.closest(j.JSXExpressionContainer)
-
-    // if the parent is an JSX expression, remove it altogether
-    // <>{toggle('foo', <A/>, <B/>)}</> becomes <></B></>
-    closestJsxExpressions.length
-      ? closestJsxExpressions.remove()
-      : callPath.remove()
+    nodeToClean.remove()
   } else {
     // use raw value
-    callPath.replaceWith(node.arguments[winnerArgumentIndex])
+    nodeToClean.replaceWith(node.arguments[winnerArgumentIndex])
   }
-
-  // clean up lingering JSX expessions with one JSXElement
-  callPath.closest(j.JSXExpressionContainer).forEach((node) => {
-    const expression = node.value.expression
-    if (expression.type === 'JSXElement') node.replace(node.value.expression)
-  })
 }
 
 const findToggleCalls = (j, context, localName) =>

--- a/src/transform/toggle.ts
+++ b/src/transform/toggle.ts
@@ -22,7 +22,7 @@ const implementWinningToggle = (
 
   // Looks for references only referred in the losing arrow function usage, 
   // and one declaration - hence 2 in total
-  const findUnusedReferencesOfType = (type, name) =>
+  const findUnusedReferencesOfType = (name) =>
     root
       .find(j.Identifier, { name })
       .size() === 2
@@ -30,7 +30,7 @@ const implementWinningToggle = (
   const removeUnusedReferences = (type, name, identifiers) =>
     root
       .find(type, identifiers)
-      .filter(findUnusedReferencesOfType.bind(null, type, name))
+      .filter(findUnusedReferencesOfType.bind(null, name))
       .remove()
 
   const losingArgumentFunctions = node.arguments.filter(
@@ -52,8 +52,6 @@ const implementWinningToggle = (
             name: name
           }
         })
-
-        // TODO: Remove imports too
       })
   })
 


### PR DESCRIPTION
The core of the fix is that previously the cleaning codemod would iterate over all "losing" sides, and remove any variable declarations if there were no other references. The issue is that it would also remove variables that were used on multiple sides of the experiment, which is actually quite common in practice.

The new solution uses a simpler algorithm, only removing if there's exactly 2 references: the declaration and the usage in the losing side. 

I am not sure if this covers all (or at least enough) scenarios so would be happy to run in on our real codebase to spot blind spots.