### PR TITLE
Run build before npm publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 > - :house: [Internal]
 > - :nail_care: [Polish]
 
+# v4.0.2
+
+- :house: Run build before NPM publish
+
 # v4.0.1
 
 - :nail_care: Fix types for initialize and addActivateListener

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clean:booleanToggle": "jscodeshift --transform lib/transform/booleanToggle.js",
     "clean:toggle": "jscodeshift --transform lib/transform/toggle.js",
     "jscodeshift": "jscodeshift",
+    "prepare": "npm run build",
     "test": "jest src",
     "test:watch": "jest --watch src"
   },


### PR DESCRIPTION
Previously we had to run `npm run build` manually and I forgot it in the last release.