### PR TITLE
Update toggle types

### DIFF
--- a/.changeset/sweet-cows-happen.md
+++ b/.changeset/sweet-cows-happen.md
@@ -1,0 +1,5 @@
+---
+'opticks': patch
+---
+
+Toggle function types update

--- a/.changeset/sweet-cows-happen.md
+++ b/.changeset/sweet-cows-happen.md
@@ -2,4 +2,4 @@
 'opticks': patch
 ---
 
-Toggle function types update
+:nail_care: Update toggle function return type

--- a/.changeset/sweet-cows-happen.md
+++ b/.changeset/sweet-cows-happen.md
@@ -2,4 +2,4 @@
 'opticks': patch
 ---
 
-:nail_care: Update toggle function return type
+:nail_care: Improve toggle function return type, which now supports anonymous function return types and mixed arguments properly

--- a/src/core/toggle.ts
+++ b/src/core/toggle.ts
@@ -1,9 +1,9 @@
-import type {ToggleIdType, TogglerGetterType} from '../types'
+import type {ToggleFuncReturnType, ToggleIdType, TogglerGetterType} from '../types'
 import {handleToggleVariant} from '../variantUtils'
 
 export const toggle =
   (getToggle: TogglerGetterType) =>
-  <T>(toggleId: ToggleIdType, ...variants: T[]): T | undefined => {
+  <T extends any[]>(toggleId: ToggleIdType, ...variants: T): ToggleFuncReturnType<T> | undefined => {
     const baseCharCode = 'a'.charCodeAt(0)
     const activeVariant = getToggle(toggleId)
     // TOOD: Write stand alone unit test for this case

--- a/src/integrations/optimizely.ts
+++ b/src/integrations/optimizely.ts
@@ -1,5 +1,5 @@
 import OptimizelyLib, {EventDispatcher} from '@optimizely/optimizely-sdk'
-import {ToggleIdType, VariantType} from '../types'
+import {ToggleFuncReturnType, ToggleIdType, VariantType} from '../types'
 import {booleanToggle as baseBooleanToggle} from '../core/booleanToggle'
 import {toggle as baseToggle} from '../core/toggle'
 
@@ -332,15 +332,8 @@ const convertBooleanToggleToFeatureVariant = (toggleId: ToggleIdType) => {
  * @param toggleId
  * @param variants
  */
-export function toggle<A = unknown>(toggleId: ToggleIdType, ...variants: A[]): A
-export function toggle(
-  toggleId: ToggleIdType,
-  ...variants: (() => unknown)[]
-): unknown
-export function toggle<A = unknown>(
-  toggleId: ToggleIdType,
-  ...variants: (A | (() => unknown))[]
-): A | unknown
+
+export function toggle<A extends any[]>(toggleId: ToggleIdType, ...variants: A): ToggleFuncReturnType<A>;
 export function toggle(toggleId: ToggleIdType, ...variants) {
   // An A/B/C... test
   if (variants.length > 2) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,3 +11,12 @@ export type ToggleType = {
 export type BooleanToggleType = boolean
 
 export type TogglerGetterType = (ToggleIdType) => any
+
+// Return type of `toggle` function
+export type ToggleFuncReturnType<ToggleFuncParams extends any[]> = {
+  [ParamKey in keyof ToggleFuncParams]: ToggleFuncParams[ParamKey] extends (
+    ...args: any[]
+  ) => infer ParamFuncReturnType
+    ? ParamFuncReturnType
+    : ToggleFuncParams[ParamKey]
+}[number]


### PR DESCRIPTION
Hey-hey!

I wanted to suggest an `toggle` function types improvement. Now we can check type of passed arguments and if it is a function we will return it's return value type, otherwise we will return argument as it was passed.

You can also check playground [here](https://www.typescriptlang.org/play?ssl=9&ssc=10&pln=3&pc=1#code/C4TwDgpgBAKg9gcwQGwgSQCY3NAvFAZ2ACcBLAOwQCgoorRJZEUIAlCYAV2PIB54kqAAoBDYiIC2BKBAAewCOQzSR5EAG0AugD4o+AN40o60eIkBpCCCgUoAaytwAZk0ERTkgpoBcrlh6kTMUlLEE0ZeUVlKAAKI1oAOiSxBAJfVQ1NIwBKPV0KJwhiKAAxTnIAY3YuHnioAH5S8qqObnI63wF-YMCA0KyAX3VyTgkAIyKsqgwICuQxaCdm4FI4cihgZlReAEEIhSUVNS1tGM23TE6t9CwcABooJISANzFSVWA0qB3sq7dqtq7bQAbioYIqayIUGIEAInGQwD0G2uMQA5HIwABaUgYVEPVEKIh4qAARgeMVyuF0I2QyGyQA).