### PR TITLE
FIX Support non-named imports

### DIFF
--- a/packages/eslint-plugin/lib/rules/toggle.js
+++ b/packages/eslint-plugin/lib/rules/toggle.js
@@ -47,7 +47,7 @@ module.exports = {
 
         if (importPath.includes('opticks')) {
           node.specifiers.forEach((specifier) => {
-            if (specifier.imported.name === 'toggle') {
+            if (specifier.imported?.name === 'toggle') {
               settings.isToggleImportedFromOpticks = true
             }
           })

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-opticks",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "An ESLint plugin for Opticks",
   "keywords": [
     "eslint",


### PR DESCRIPTION
The `toggle` rule breaks for non-named imports like this:

```
import * as Opticks from 'opticks'
```

This fixes it by checking if `specifier.imported` exists while testing the import path.